### PR TITLE
Refactor : 상품 등록 기능 수정

### DIFF
--- a/src/main/java/com/itonse/clotheslink/customer/service/Impl/CustomerAuthServiceImpl.java
+++ b/src/main/java/com/itonse/clotheslink/customer/service/Impl/CustomerAuthServiceImpl.java
@@ -12,6 +12,7 @@ import com.itonse.clotheslink.exception.CustomException;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.itonse.clotheslink.exception.ErrorCode.*;
 
@@ -23,6 +24,7 @@ public class CustomerAuthServiceImpl implements CustomerAuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
+    @Transactional
     public UserInfoResponse signUp(SignUpDto dto) {
 
         customerRepository.findByEmail(dto.getEmail()).ifPresent(e -> {

--- a/src/main/java/com/itonse/clotheslink/product/repository/CategoryRepository.java
+++ b/src/main/java/com/itonse/clotheslink/product/repository/CategoryRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByName(String name);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/itonse/clotheslink/product/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/com/itonse/clotheslink/product/service/Impl/CategoryServiceImpl.java
@@ -6,6 +6,7 @@ import com.itonse.clotheslink.product.repository.CategoryRepository;
 import com.itonse.clotheslink.product.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.itonse.clotheslink.exception.ErrorCode.ALREADY_REGISTERED_CATEGORY;
 import static com.itonse.clotheslink.exception.ErrorCode.EMPTY_CATEGORY_NAME;
@@ -17,6 +18,7 @@ public class CategoryServiceImpl implements CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Override
+    @Transactional
     public String addCategory(String categoryName) {
         validateCategoryName(categoryName);
 
@@ -33,8 +35,8 @@ public class CategoryServiceImpl implements CategoryService {
             throw new CustomException(EMPTY_CATEGORY_NAME);
         }
 
-        categoryRepository.findByName(categoryName).ifPresent( e -> {
+        if (categoryRepository.existsByName(categoryName)) {
             throw new CustomException(ALREADY_REGISTERED_CATEGORY);
-        });
+        }
     }
 }

--- a/src/main/java/com/itonse/clotheslink/seller/service/Impl/SellerAuthServiceImpl.java
+++ b/src/main/java/com/itonse/clotheslink/seller/service/Impl/SellerAuthServiceImpl.java
@@ -11,6 +11,7 @@ import com.itonse.clotheslink.seller.repository.SellerRepository;
 import com.itonse.clotheslink.seller.service.SellerAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.itonse.clotheslink.exception.ErrorCode.*;
 
@@ -21,6 +22,8 @@ public class SellerAuthServiceImpl implements SellerAuthService {
     private final SellerRepository sellerRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Override
+    @Transactional
     public UserInfoResponse signUp(SignUpDto dto) {
 
         Seller seller = SignUpDto.toSellerEntity(dto);


### PR DESCRIPTION
카테고리 이름이 이미 존재하는지 여부만 필요하고, 카테고리 객체를 가져올 필요는 없어 existsByName 을 수행하도록 변경

원자성 보장 및 데이터 충돌 방지를 위해 일부 서비스 메소드에 @Transactional 어노테이션 추가

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 카테고리 이름이 이미 존재하는지 여부만 필요하고, 카테고리 객체를 가져올 필요는 없어 existsByName 을 수행하도록 변경
- 원자성 보장 및 데이터 충돌 방지를 위해 일부 서비스 메소드에 @Transactional 어노테이션 추가

**TO-BE**
seller, customer, admin 패키지 변경

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
