### PR TITLE
Feat : 장바구니에 상품 담기, 수량 수정 기능 추가 

### DIFF
--- a/src/main/java/com/itonse/clotheslink/cart/controller/CartController.java
+++ b/src/main/java/com/itonse/clotheslink/cart/controller/CartController.java
@@ -24,4 +24,13 @@ public class CartController {
         return ResponseEntity.ok()
                 .body(cartService.addNewProduct(token, CartForm.toCartDto(form)));
     }
+
+    @PatchMapping("product/count")
+    public ResponseEntity<CartInfo> modifyProductQuantity(
+            @RequestHeader(name = "Authorization") String token,
+            @RequestBody @Valid CartForm form) {
+
+        return ResponseEntity.ok()
+                .body(cartService.modifyProductQuantity(token, CartForm.toCartDto(form)));
+    }
 }

--- a/src/main/java/com/itonse/clotheslink/cart/controller/CartController.java
+++ b/src/main/java/com/itonse/clotheslink/cart/controller/CartController.java
@@ -1,0 +1,27 @@
+package com.itonse.clotheslink.cart.controller;
+
+import com.itonse.clotheslink.cart.dto.CartForm;
+import com.itonse.clotheslink.cart.dto.CartInfo;
+import com.itonse.clotheslink.cart.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RequestMapping("/cart")
+@RequiredArgsConstructor
+@RestController
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping("product/new")
+    public ResponseEntity<CartInfo> addNewProduct(
+            @RequestHeader(name = "Authorization") String token,
+            @RequestBody @Valid CartForm form) {
+
+        return ResponseEntity.ok()
+                .body(cartService.addNewProduct(token, CartForm.toCartDto(form)));
+    }
+}

--- a/src/main/java/com/itonse/clotheslink/cart/domain/Cart.java
+++ b/src/main/java/com/itonse/clotheslink/cart/domain/Cart.java
@@ -1,0 +1,31 @@
+package com.itonse.clotheslink.cart.domain;
+
+import com.itonse.clotheslink.common.BaseEntity;
+import com.itonse.clotheslink.product.domain.Product;
+import com.itonse.clotheslink.user.domain.Customer;
+import lombok.*;
+
+import javax.persistence.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+@Getter
+@Entity
+public class Cart extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int count;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+}

--- a/src/main/java/com/itonse/clotheslink/cart/dto/CartDto.java
+++ b/src/main/java/com/itonse/clotheslink/cart/dto/CartDto.java
@@ -1,0 +1,16 @@
+package com.itonse.clotheslink.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class CartDto {
+
+    private Long productId;
+    private int count;
+}

--- a/src/main/java/com/itonse/clotheslink/cart/dto/CartForm.java
+++ b/src/main/java/com/itonse/clotheslink/cart/dto/CartForm.java
@@ -1,0 +1,28 @@
+package com.itonse.clotheslink.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class CartForm {
+
+    @NotNull(message = "상품번호를 입력해주세요.")
+    private Long productId;
+
+    @NotNull(message = "수량을 입력해 주세요.")
+    private int count;
+
+    public static CartDto toCartDto(CartForm form) {
+        return CartDto.builder()
+                .productId(form.getProductId())
+                .count(form.getCount())
+                .build();
+    }
+}

--- a/src/main/java/com/itonse/clotheslink/cart/dto/CartInfo.java
+++ b/src/main/java/com/itonse/clotheslink/cart/dto/CartInfo.java
@@ -1,0 +1,18 @@
+package com.itonse.clotheslink.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class CartInfo {
+
+    private Long id;
+    private int count;
+    private Long productId;
+    private Long customerId;
+}

--- a/src/main/java/com/itonse/clotheslink/cart/dto/ValidationResult.java
+++ b/src/main/java/com/itonse/clotheslink/cart/dto/ValidationResult.java
@@ -1,0 +1,18 @@
+package com.itonse.clotheslink.cart.dto;
+
+import com.itonse.clotheslink.product.domain.Product;
+import com.itonse.clotheslink.user.domain.Customer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ValidationResult {
+
+    private Product product;
+    private Customer customer;
+}

--- a/src/main/java/com/itonse/clotheslink/cart/repository/CartRepository.java
+++ b/src/main/java/com/itonse/clotheslink/cart/repository/CartRepository.java
@@ -6,8 +6,12 @@ import com.itonse.clotheslink.user.domain.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
         boolean existsByProductAndCustomer(Product product, Customer customer);
+
+        Optional<Cart> findByProductAndCustomer(Product product, Customer customer);
 }

--- a/src/main/java/com/itonse/clotheslink/cart/repository/CartRepository.java
+++ b/src/main/java/com/itonse/clotheslink/cart/repository/CartRepository.java
@@ -1,0 +1,13 @@
+package com.itonse.clotheslink.cart.repository;
+
+import com.itonse.clotheslink.cart.domain.Cart;
+import com.itonse.clotheslink.product.domain.Product;
+import com.itonse.clotheslink.user.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+        boolean existsByProductAndCustomer(Product product, Customer customer);
+}

--- a/src/main/java/com/itonse/clotheslink/cart/service/CartService.java
+++ b/src/main/java/com/itonse/clotheslink/cart/service/CartService.java
@@ -8,6 +8,8 @@ import com.itonse.clotheslink.product.domain.Product;
 public interface CartService {
     CartInfo addNewProduct(String token, CartDto dto);
 
+    CartInfo modifyProductQuantity(String token, CartDto dto);
+
     ValidationResult validateCustomerAndProduct(String token, CartDto dto);
 
     void checkProductQuantity(Product product, int count);

--- a/src/main/java/com/itonse/clotheslink/cart/service/CartService.java
+++ b/src/main/java/com/itonse/clotheslink/cart/service/CartService.java
@@ -1,0 +1,14 @@
+package com.itonse.clotheslink.cart.service;
+
+import com.itonse.clotheslink.cart.dto.CartDto;
+import com.itonse.clotheslink.cart.dto.CartInfo;
+import com.itonse.clotheslink.cart.dto.ValidationResult;
+import com.itonse.clotheslink.product.domain.Product;
+
+public interface CartService {
+    CartInfo addNewProduct(String token, CartDto dto);
+
+    ValidationResult validateCustomerAndProduct(String token, CartDto dto);
+
+    void checkProductQuantity(Product product, int count);
+}

--- a/src/main/java/com/itonse/clotheslink/cart/service/Impl/CartServiceImpl.java
+++ b/src/main/java/com/itonse/clotheslink/cart/service/Impl/CartServiceImpl.java
@@ -54,6 +54,28 @@ public class CartServiceImpl implements CartService {
     }
 
     @Override
+    @Transactional
+    public CartInfo modifyProductQuantity(String token, CartDto dto) {
+        ValidationResult result = validateCustomerAndProduct(token, dto);
+        Customer customer = result.getCustomer();
+        Product product = result.getProduct();
+
+        Cart cart = cartRepository.findByProductAndCustomer(product, customer)
+                .orElseThrow(() -> new CustomException(NOT_EXISTS_CART));
+
+        int totalCount = cart.getCount() + dto.getCount();
+        checkProductQuantity(product, totalCount);
+        cart.setCount(totalCount);
+
+        return CartInfo.builder()
+                .id(cart.getId())
+                .count(cart.getCount())
+                .productId(product.getId())
+                .customerId(customer.getId())
+                .build();
+    }
+
+    @Override
     public ValidationResult validateCustomerAndProduct(String token, CartDto dto) {
         Customer customer = customerAuthService.validateCustomer(token);
 

--- a/src/main/java/com/itonse/clotheslink/cart/service/Impl/CartServiceImpl.java
+++ b/src/main/java/com/itonse/clotheslink/cart/service/Impl/CartServiceImpl.java
@@ -1,0 +1,82 @@
+package com.itonse.clotheslink.cart.service.Impl;
+
+import com.itonse.clotheslink.cart.domain.Cart;
+import com.itonse.clotheslink.cart.dto.CartDto;
+import com.itonse.clotheslink.cart.dto.CartInfo;
+import com.itonse.clotheslink.cart.dto.ValidationResult;
+import com.itonse.clotheslink.cart.repository.CartRepository;
+import com.itonse.clotheslink.cart.service.CartService;
+import com.itonse.clotheslink.exception.CustomException;
+import com.itonse.clotheslink.product.domain.Product;
+import com.itonse.clotheslink.product.repository.ProductRepository;
+import com.itonse.clotheslink.user.domain.Customer;
+import com.itonse.clotheslink.user.service.CustomerAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.itonse.clotheslink.exception.ErrorCode.*;
+
+@RequiredArgsConstructor
+@Service
+public class CartServiceImpl implements CartService {
+
+    private final CartRepository cartRepository;
+    private final ProductRepository productRepository;
+    private final CustomerAuthService customerAuthService;
+
+    @Override
+    @Transactional
+    public CartInfo addNewProduct(String token, CartDto dto) {
+        ValidationResult result = validateCustomerAndProduct(token, dto);
+        Customer customer = result.getCustomer();
+        Product product = result.getProduct();
+
+        if (cartRepository.existsByProductAndCustomer(product, customer)) {
+            throw new CustomException(ALREADY_EXISTS_CART);
+        }
+        checkProductQuantity(product, dto.getCount());
+
+        Cart cart = Cart.builder()
+                .count(dto.getCount())
+                .product(product)
+                .customer(customer)
+                .build();
+
+        cartRepository.save(cart);
+
+        return CartInfo.builder()
+                .id(cart.getId())
+                .count(cart.getCount())
+                .productId(product.getId())
+                .customerId(customer.getId())
+                .build();
+    }
+
+    @Override
+    public ValidationResult validateCustomerAndProduct(String token, CartDto dto) {
+        Customer customer = customerAuthService.validateCustomer(token);
+
+        Product product = productRepository.findById(dto.getProductId())
+                .orElseThrow(() -> new CustomException(NOT_EXISTS_PRODUCT));
+
+        if (product.isDeleted()) {
+            throw new CustomException(SALES_STOPPED_PRODUCT);
+        }
+
+        return ValidationResult.builder()
+                .customer(customer)
+                .product(product)
+                .build();
+    }
+
+    @Override
+    public void checkProductQuantity(Product product, int count) {
+        if (count < 1) {
+            throw new CustomException(INVALID_QUANTITY);
+        }
+        if (product.getStock() < count) {
+            throw new CustomException(EXCEEDED_STOCK_QUANTITY);
+        }
+    }
+}

--- a/src/main/java/com/itonse/clotheslink/exception/ErrorCode.java
+++ b/src/main/java/com/itonse/clotheslink/exception/ErrorCode.java
@@ -18,12 +18,19 @@ public enum ErrorCode {
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증코드 입니다."),
     EXPIRED_AUTH_CODE(HttpStatus.BAD_REQUEST, "만료된 인증코드 입니다."),
     INITIATE_EMAIL_REQUEST(HttpStatus.BAD_REQUEST, "먼저 이메일 요청을 진행해주세요."),
+
     ALREADY_REGISTERED_CATEGORY(HttpStatus.BAD_REQUEST, "이미 등록된 카테고리 입니다."),
     NOT_EXISTS_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리 입니다."),
     EMPTY_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "카테고리 이름은 최소 한 글자 이상입니다."),
-    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "인증된 판매자가 아닙니다."),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "인증된 회원이 아닙니다."),
+    UNAUTHORIZED_CUSTOMER(HttpStatus.UNAUTHORIZED, "인증된 고객이 아닙니다."),
     NOT_EXISTS_PRODUCT(HttpStatus.BAD_REQUEST, "상품이 존재하지 않습니다."),
-    NOT_SELLERS_PRODUCT(HttpStatus.BAD_REQUEST, "판매자의 상품이 아닙니다.");
+    NOT_SELLERS_PRODUCT(HttpStatus.BAD_REQUEST, "판매자의 상품이 아닙니다."),
+
+    SALES_STOPPED_PRODUCT(HttpStatus.BAD_REQUEST, "판매 중지된 상품입니다."),
+    EXCEEDED_STOCK_QUANTITY(HttpStatus.BAD_REQUEST, "상품의 재고보다 수량을 초과했습니다."),
+    ALREADY_EXISTS_CART(HttpStatus.BAD_REQUEST, "해당 상품은 이미 장바구니에 존재합니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량은 0개 이상 담아야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/itonse/clotheslink/exception/ErrorCode.java
+++ b/src/main/java/com/itonse/clotheslink/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
     SALES_STOPPED_PRODUCT(HttpStatus.BAD_REQUEST, "판매 중지된 상품입니다."),
     EXCEEDED_STOCK_QUANTITY(HttpStatus.BAD_REQUEST, "상품의 재고보다 수량을 초과했습니다."),
     ALREADY_EXISTS_CART(HttpStatus.BAD_REQUEST, "해당 상품은 이미 장바구니에 존재합니다."),
-    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량은 0개 이상 담아야 합니다.");
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량은 0개 이상 담아야 합니다."),
+    NOT_EXISTS_CART(HttpStatus.BAD_REQUEST, "해당 상품이 카트에 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/itonse/clotheslink/user/domain/Customer.java
+++ b/src/main/java/com/itonse/clotheslink/user/domain/Customer.java
@@ -1,10 +1,13 @@
 package com.itonse.clotheslink.user.domain;
 
+import com.itonse.clotheslink.cart.domain.Cart;
 import com.itonse.clotheslink.common.BaseEntity;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -24,4 +27,7 @@ public class Customer extends BaseEntity {
     private String password;
     private String phone;
     private boolean authenticated;
+
+    @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL)
+    private List<Cart> carts = new ArrayList<>();
 }

--- a/src/main/java/com/itonse/clotheslink/user/service/CustomerAuthService.java
+++ b/src/main/java/com/itonse/clotheslink/user/service/CustomerAuthService.java
@@ -12,4 +12,6 @@ public interface CustomerAuthService {
     String signIn(SignInDto dto);
 
     Customer findCustomerByToken(String token);
+
+    Customer validateCustomer(String token);
 }

--- a/src/main/java/com/itonse/clotheslink/user/service/Impl/CustomerAuthServiceImpl.java
+++ b/src/main/java/com/itonse/clotheslink/user/service/Impl/CustomerAuthServiceImpl.java
@@ -65,4 +65,15 @@ public class CustomerAuthServiceImpl implements CustomerAuthService {
         return customerRepository.findByIdAndEmail(vo.getId(), vo.getEmail())
                 .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
     }
+
+    @Override
+    public Customer validateCustomer(String token) {
+        Customer customer = findCustomerByToken(token);
+
+        if (!customer.isAuthenticated()) {
+            throw new CustomException(UNAUTHORIZED_CUSTOMER);
+        }
+
+        return customer;
+    }
 }

--- a/src/test/http/Cart/cart.http
+++ b/src/test/http/Cart/cart.http
@@ -1,0 +1,9 @@
+### 카트에 상품 담기
+POST http://localhost:8080/cart/product/new
+Content-Type: application/json
+Authorization:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJvbmVAbmF2ZXIuY29tIiwianRpIjoiMSIsInJvbGVzIjoiQ1VTVE9NRVIiLCJpYXQiOjE2ODk0Nzg3OTcsImV4cCI6MTY4OTQ4OTU5N30.QlvB6Hij26TUl-SxIVmmZgnKTX5xkOTtvwNZbZl8oqQ
+
+{
+  "productId": 16,
+  "count": 1
+}

--- a/src/test/http/Cart/cart.http
+++ b/src/test/http/Cart/cart.http
@@ -7,3 +7,13 @@ Authorization:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJvbmVAbmF2ZXIuY29tIiwianRpIjoiMSIsI
   "productId": 16,
   "count": 1
 }
+
+### 카트에 있는 상품의 수량 변경
+PATCH http://localhost:8080/cart/product/count
+Content-Type: application/json
+Authorization:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJvbmVAbmF2ZXIuY29tIiwianRpIjoiMSIsInJvbGVzIjoiQ1VTVE9NRVIiLCJpYXQiOjE2ODk0Nzg3OTcsImV4cCI6MTY4OTQ4OTU5N30.QlvB6Hij26TUl-SxIVmmZgnKTX5xkOTtvwNZbZl8oqQ
+
+{
+  "productId": 16,
+  "count": 3
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
장바구니에 접근하려면 회원(고객) 로그인, 본인인증 필요

- **상품 추가 기능**
  이미 장바구니에 해당 상품이 있으면 에러처리
  상품은 1개 이상, 재고 이하의 개수만 담을 수 있다
  판매 중지된 상품은 담기 불가능

- **담은 상품 수량 수정 기능**
  장바구니에 해당 상품이 없으면 에러처리
  상품은 1개 이상, 재고 이하의 개수만 담을 수 있다
  판매 중지된 상품은 수량 수정 불가능

**TO-BE**
장바구니 상품 삭제 기능 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
